### PR TITLE
Make ch5_load.sh script more robust

### DIFF
--- a/data/ch5/ch5_load.sh
+++ b/data/ch5/ch5_load.sh
@@ -1,29 +1,46 @@
 #!/bin/bash
 
-cd /path/to/dse-6.8.0_20190911-LABS/dsbulk-1.3.4/bin
+# customizable variables
+DSBULK_PATH=/path/to/dse-6.8.0_20190911-LABS/dsbulk-1.3.4
+DEST_KS=neighborhoods_prod
 
-echo "Loading vertices into the graph neighborhoods_prod"
+# 
+OLDWD="`pwd`"
+SCRIPTIR="`dirname $0`"
+cd "$SCRIPTDIR"
+DATADIR="`pwd`"
 
-./dsbulk load -k neighborhoods_prod -t Transaction -url /path/to/graph-book/data/ch5/Transactions.csv -header true -schema.allowMissingFields true
-./dsbulk load -k neighborhoods_prod -t Vendor -url /path/to/graph-book/data/ch5/Vendors.csv -header true -schema.allowMissingFields true
-./dsbulk load -k neighborhoods_prod -t Customer -url /path/to/graph-book/data/ch5/Customers.csv -header true -schema.allowMissingFields true
-./dsbulk load -k neighborhoods_prod -t Loan -url /path/to/graph-book/data/ch5/Loans.csv -header true -schema.allowMissingFields true
-./dsbulk load -k neighborhoods_prod -t Account -url /path/to/graph-book/data/ch5/Accounts.csv -header true -schema.allowMissingFields true
-./dsbulk load -k neighborhoods_prod -t CreditCard -url /path/to/graph-book/data/ch5/CreditCards.csv -header true -schema.allowMissingFields true
+DSBULK="`which dsbulk`"
+if [ -z "$DSBULK" ]; then
+    if [ ! -f "$DSBULK_PATH/bin/dsbulk" ]; then
+        echo "Please set DSBULK_PATH variable to top-level path of DSBulk distribution"
+        echo "  or add directory with dsbulk to PATH, like, 'PATH=...dsbulk-1.3.4/bin:\$PATH'"
+        exit 1
+    fi
+fi
 
-echo "Completed loading vertices into the graph neighborhoods_prod."
+echo "Loading vertices into the graph $DEST_KS"
 
-echo "Loading edges into the graph neighborhoods_prod"
+$DSBULK load -k $DEST_KS -t Transaction -url "$DATADIR/Transactions.csv" -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Vendor -url "$DATADIR/Vendors.csv" -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Customer -url "$DATADIR/Customers.csv" -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Loan -url "$DATADIR/Loans.csv" -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Account -url "$DATADIR/Accounts.csv" -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t CreditCard -url "$DATADIR/CreditCards.csv" -header true --schema.allowMissingFields true
 
-./dsbulk load -k neighborhoods_prod -t Customer__owes__Loan -url /path/to/graph-book/data/ch5/owes.csv -header true -schema.allowMissingFields true
-./dsbulk load -k neighborhoods_prod -t Customer__owns__Account -url /path/to/graph-book/data/ch5/owns.csv -header true -schema.allowMissingFields true
-./dsbulk load -k neighborhoods_prod -t Customer__uses__CreditCard -url /path/to/graph-book/data/ch5/uses.csv -header true -schema.allowMissingFields true
-./dsbulk load -k neighborhoods_prod -t Transaction__charge__CreditCard -url /path/to/graph-book/data/ch5/charge.csv -header true -schema.allowMissingFields true
-./dsbulk load -k neighborhoods_prod -t Transaction__deposit_to__Account -url /path/to/graph-book/data/ch5/deposit_to.csv -header true -schema.allowMissingFields true
-./dsbulk load -k neighborhoods_prod -t Transaction__withdraw_from__Account -url /path/to/graph-book/data/ch5/withdraw_from.csv -header true -schema.allowMissingFields true
-./dsbulk load -k neighborhoods_prod -t Transaction__pay__Loan -url /path/to/graph-book/data/ch5/pay_loan.csv -header true -schema.allowMissingFields true
-./dsbulk load -k neighborhoods_prod -t Transaction__pay__Vendor -url /path/to/graph-book/data/ch5/pay_vendor.csv -header true -schema.allowMissingFields true
+echo "Completed loading vertices into the graph $DEST_KS."
 
-echo "Completed loading edges into the graph neighborhoods_prod."
+echo "Loading edges into the graph $DEST_KS"
 
-cd /path/to/graph-book/data/ch5
+$DSBULK load -k $DEST_KS -t Customer__owes__Loan -url "$DATADIR/owes.csv" -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Customer__owns__Account -url "$DATADIR/owns.csv" -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Customer__uses__CreditCard -url "$DATADIR/uses.csv" -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Transaction__charge__CreditCard -url "$DATADIR/charge.csv" -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Transaction__deposit_to__Account -url "$DATADIR/deposit_to.csv" -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Transaction__withdraw_from__Account -url "$DATADIR/withdraw_from.csv" -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Transaction__pay__Loan -url "$DATADIR/pay_loan.csv" -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Transaction__pay__Vendor -url "$DATADIR/pay_vendor.csv" -header true --schema.allowMissingFields true
+
+echo "Completed loading edges into the graph $DEST_KS."
+
+cd "$OLDWD"


### PR DESCRIPTION
multiple changes:
* Automatically detect path to the data
* use DSBulk from PATH if it's there
* Allow to customize destination keyspace/graph
* fix for DSBulk 1.3.4 vs 1.4.0 compatibility issue: `-schema.allowMissingFields`  doesn't
  work with 1.4.0 - we must use `--schema.allowMissingFields`