### PR TITLE
Improve specification of variables in ch5 data loading script

### DIFF
--- a/data/ch10/ch10_load.sh
+++ b/data/ch10/ch10_load.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-# Please set the following variables
-DSBULK_PATH=/PATH/TO/dsbulk-1.3.4
-DEST_KS=movies_dev
+# You may set the following variables inside script, or override corresponding
+# variables when running the script
+DEFAULT_DSBULK_PATH=/PATH/TO/dsbulk-1.3.4
+DEFAULT_DESK_KS=movies_dev
+
+# Allow to override these variables via environment variables set before executing script
+DSBULK_PATH=${DSBULK_PATH:-$DEFAULT_DSBULK_PATH}
+DEST_KS=${DEST_KS:-$DEFAULT_DESK_KS}
 
 ############################################
 # Automated data loading
@@ -13,18 +18,18 @@ DEST_KS=movies_dev
 OLDWD="`pwd`"
 SCRIPTIR="`dirname $0`"
 cd "$SCRIPTDIR"
-DATADIR="`pwd`"
 
 # determine which dsbulk to use, in the case you already have it installed
-DSBULK="`which dsbulk`"
-if [ -z "$DSBULK" ]; then
-    if [ ! -f "$DSBULK_PATH/bin/dsbulk" ]; then
+# the path that is set in the script, takes over the value from PATH
+DSBULK=$DSBULK_PATH/bin/dsbulk
+if [ ! -f "$DSBULK" ]; then
+    DSBULK="`which dsbulk`"
+    if [ -z "$DSBULK" ]; then
         echo "Please set DSBULK_PATH variable to top-level path of DSBulk distribution"
         echo "  or add directory with dsbulk to PATH, like, 'PATH=...dsbulk-1.3.4/bin:\$PATH'"
         exit 1
     fi
 fi
-DSBULK=$DSBULK_PATH/bin/dsbulk
 
 ############################################
 # load the vertices
@@ -35,11 +40,11 @@ echo "Extracting data files for loading..."
 tar xvzf movies_dev_data.tar.gz
 
 echo "Loading vertices into the graph $DEST_KS"
-$DSBULK load -k $DEST_KS -t Movie -url "$DATADIR/Movie.csv" -header true
-$DSBULK load -k $DEST_KS -t User -url "$DATADIR/User.csv" -header true
-$DSBULK load -k $DEST_KS -t Tag -url "$DATADIR/Tag.csv" -header true
-$DSBULK load -k $DEST_KS -t Genre -url "$DATADIR/Genre.csv" -header true
-$DSBULK load -k $DEST_KS -t Actor -url "$DATADIR/Actor.csv" -header true
+$DSBULK load -k $DEST_KS -t Movie -url Movie.csv -header true
+$DSBULK load -k $DEST_KS -t User -url User.csv -header true
+$DSBULK load -k $DEST_KS -t Tag -url Tag.csv -header true
+$DSBULK load -k $DEST_KS -t Genre -url Genre.csv -header true
+$DSBULK load -k $DEST_KS -t Actor -url Actor.csv -header true
 
 echo "Completed loading vertices into the graph $DEST_KS."
 
@@ -48,12 +53,12 @@ echo "Completed loading vertices into the graph $DEST_KS."
 ############################################
 echo "Loading edges into the graph $DEST_KS"
 
-$DSBULK load -k $DEST_KS -t Movie__belongs_to__Genre -url "$DATADIR/belongs_to.csv" -header true
-$DSBULK load -k $DEST_KS -t Movie__topic_tagged__Tag -url "$DATADIR/topic_tag_100k_sample.csv" -header true
-$DSBULK load -k $DEST_KS -t User__rated__Movie -url "$DATADIR/rated_100k_sample.csv" -header true
-$DSBULK load -k $DEST_KS -t User__tagged__Movie -url "$DATADIR/tagged.csv" -header true
-$DSBULK load -k $DEST_KS -t Actor__acted_in__Movie -url "$DATADIR/acted_in.csv" -header true
-$DSBULK load -k $DEST_KS -t Actor__collaborated_with__Actor -url "$DATADIR/collaborator.csv" -header true
+$DSBULK load -k $DEST_KS -t Movie__belongs_to__Genre -url belongs_to.csv -header true
+$DSBULK load -k $DEST_KS -t Movie__topic_tagged__Tag -url topic_tag_100k_sample.csv -header true
+$DSBULK load -k $DEST_KS -t User__rated__Movie -url rated_100k_sample.csv -header true
+$DSBULK load -k $DEST_KS -t User__tagged__Movie -url tagged.csv -header true
+$DSBULK load -k $DEST_KS -t Actor__acted_in__Movie -url acted_in.csv -header true
+$DSBULK load -k $DEST_KS -t Actor__collaborated_with__Actor -url collaborator.csv -header true
 
 echo "Completed loading edges into the graph $DEST_KS."
 

--- a/data/ch4/ch4_load.sh
+++ b/data/ch4/ch4_load.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-# Please set the following variables
-DSBULK_PATH=/PATH/TO/dsbulk-1.3.4
-DEST_KS=neighborhoods_dev
+# You may set the following variables inside script, or override corresponding
+# variables when running the script
+DEFAULT_DSBULK_PATH=/PATH/TO/dsbulk-1.3.4
+DEFAULT_DESK_KS=neighborhoods_dev
+
+# Allow to override these variables via environment variables set before executing script
+DSBULK_PATH=${DSBULK_PATH:-$DEFAULT_DSBULK_PATH}
+DEST_KS=${DEST_KS:-$DEFAULT_DESK_KS}
 
 ############################################
 # Automated data loading 
@@ -13,47 +18,47 @@ DEST_KS=neighborhoods_dev
 OLDWD="`pwd`"
 SCRIPTIR="`dirname $0`"
 cd "$SCRIPTDIR"
-DATADIR="`pwd`"
 
 # determine which dsbulk to use, in the case you already have it installed
-DSBULK="`which dsbulk`"
-if [ -z "$DSBULK" ]; then
-    if [ ! -f "$DSBULK_PATH/bin/dsbulk" ]; then
+# the path that is set in the script, takes over the value from PATH
+DSBULK=$DSBULK_PATH/bin/dsbulk
+if [ ! -f "$DSBULK" ]; then
+    DSBULK="`which dsbulk`"
+    if [ -z "$DSBULK" ]; then
         echo "Please set DSBULK_PATH variable to top-level path of DSBulk distribution"
         echo "  or add directory with dsbulk to PATH, like, 'PATH=...dsbulk-1.3.4/bin:\$PATH'"
         exit 1
     fi
 fi
-DSBULK=$DSBULK_PATH/bin/dsbulk
 
 ############################################
 # load the vertices
 ############################################
 echo "Loading vertices into the graph $DEST_KS"
 
-$DSBULK load -k neighborhoods_dev -t Transaction -url /path/to/graph-book/data/ch4/Transactions.csv -header true -schema.allowMissingFields true
-$DSBULK load -k neighborhoods_dev -t Vendor -url /path/to/graph-book/data/ch4/Vendors.csv -header true -schema.allowMissingFields true
-$DSBULK load -k neighborhoods_dev -t Customer -url /path/to/graph-book/data/ch4/Customers.csv -header true -schema.allowMissingFields true
-$DSBULK load -k neighborhoods_dev -t Loan -url /path/to/graph-book/data/ch4/Loans.csv -header true -schema.allowMissingFields true
-$DSBULK load -k neighborhoods_dev -t Account -url /path/to/graph-book/data/ch4/Accounts.csv -header true -schema.allowMissingFields true
-$DSBULK load -k neighborhoods_dev -t CreditCard -url /path/to/graph-book/data/ch4/CreditCards.csv -header true -schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Transaction -url Transactions.csv -header true -schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Vendor -url Vendors.csv -header true -schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Customer -url Customers.csv -header true -schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Loan -url Loans.csv -header true -schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Account -url Accounts.csv -header true -schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t CreditCard -url CreditCards.csv -header true -schema.allowMissingFields true
 
-echo "Completed loading vertices into the graph neighborhoods_dev."
+echo "Completed loading vertices into the graph $DEST_KS."
 
 ############################################
 # load the edges
 ############################################
-echo "Loading edges into the graph neighborhoods_dev"
+echo "Loading edges into the graph $DEST_KS"
 
-$DSBULK load -k neighborhoods_dev -t Customer__owes__Loan -url /path/to/graph-book/data/ch4/owes.csv -header true -schema.allowMissingFields true
-$DSBULK load -k neighborhoods_dev -t Customer__owns__Account -url /path/to/graph-book/data/ch4/owns.csv -header true -schema.allowMissingFields true
-$DSBULK load -k neighborhoods_dev -t Customer__uses__CreditCard -url /path/to/graph-book/data/ch4/uses.csv -header true -schema.allowMissingFields true
-$DSBULK load -k neighborhoods_dev -t Transaction__charge__CreditCard -url /path/to/graph-book/data/ch4/charge.csv -header true -schema.allowMissingFields true
-$DSBULK load -k neighborhoods_dev -t Transaction__deposit_to__Account -url /path/to/graph-book/data/ch4/deposit_to.csv -header true -schema.allowMissingFields true
-$DSBULK load -k neighborhoods_dev -t Transaction__withdraw_from__Account -url /path/to/graph-book/data/ch4/withdraw_from.csv -header true -schema.allowMissingFields true
-$DSBULK load -k neighborhoods_dev -t Transaction__pay__Loan -url /path/to/graph-book/data/ch4/pay_loan.csv -header true -schema.allowMissingFields true
-$DSBULK load -k neighborhoods_dev -t Transaction__pay__Vendor -url /path/to/graph-book/data/ch4/pay_vendor.csv -header true -schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Customer__owes__Loan -url owes.csv -header true -schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Customer__owns__Account -url owns.csv -header true -schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Customer__uses__CreditCard -url uses.csv -header true -schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Transaction__charge__CreditCard -url charge.csv -header true -schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Transaction__deposit_to__Account -url deposit_to.csv -header true -schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Transaction__withdraw_from__Account -url withdraw_from.csv -header true -schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Transaction__pay__Loan -url pay_loan.csv -header true -schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Transaction__pay__Vendor -url pay_vendor.csv -header true -schema.allowMissingFields true
 
-echo "Completed loading edges into the graph neighborhoods_dev."
+echo "Completed loading edges into the graph $DEST_KS."
 
 cd "$OLDWD"

--- a/data/ch5/ch5_load.sh
+++ b/data/ch5/ch5_load.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-# Please set the following variables
-DSBULK_PATH=/PATH/TO/dsbulk-1.3.4
-DEST_KS=neighborhoods_prod
+# You may set the following variables inside script, or override corresponding
+# variables when running the script
+DEFAULT_DSBULK_PATH=/PATH/TO/dsbulk-1.3.4
+DEFAULT_DESK_KS=neighborhoods_prod
+
+# Allow to override these variables via environment variables set before executing script
+DSBULK_PATH=${DSBULK_PATH:-$DEFAULT_DSBULK_PATH}
+DEST_KS=${DEST_KS:-$DEFAULT_DESK_KS}
 
 ############################################
 # Automated data loading
@@ -13,30 +18,30 @@ DEST_KS=neighborhoods_prod
 OLDWD="`pwd`"
 SCRIPTIR="`dirname $0`"
 cd "$SCRIPTDIR"
-DATADIR="`pwd`"
 
 # determine which dsbulk to use, in the case you already have it installed
-DSBULK="`which dsbulk`"
-if [ -z "$DSBULK" ]; then
-    if [ ! -f "$DSBULK_PATH/bin/dsbulk" ]; then
+# the path that is set in the script, takes over the value from PATH
+DSBULK=$DSBULK_PATH/bin/dsbulk
+if [ ! -f "$DSBULK" ]; then
+    DSBULK="`which dsbulk`"
+    if [ -z "$DSBULK" ]; then
         echo "Please set DSBULK_PATH variable to top-level path of DSBulk distribution"
         echo "  or add directory with dsbulk to PATH, like, 'PATH=...dsbulk-1.3.4/bin:\$PATH'"
         exit 1
     fi
 fi
-DSBULK=$DSBULK_PATH/bin/dsbulk
 
 ############################################
 # load the vertices
 ############################################
 echo "Loading vertices into the graph $DEST_KS"
 
-$DSBULK load -k $DEST_KS -t Transaction -url "$DATADIR/Transactions.csv" -header true --schema.allowMissingFields true
-$DSBULK load -k $DEST_KS -t Vendor -url "$DATADIR/Vendors.csv" -header true --schema.allowMissingFields true
-$DSBULK load -k $DEST_KS -t Customer -url "$DATADIR/Customers.csv" -header true --schema.allowMissingFields true
-$DSBULK load -k $DEST_KS -t Loan -url "$DATADIR/Loans.csv" -header true --schema.allowMissingFields true
-$DSBULK load -k $DEST_KS -t Account -url "$DATADIR/Accounts.csv" -header true --schema.allowMissingFields true
-$DSBULK load -k $DEST_KS -t CreditCard -url "$DATADIR/CreditCards.csv" -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Transaction -url Transactions.csv -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Vendor -url Vendors.csv -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Customer -url Customers.csv -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Loan -url Loans.csv -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Account -url Accounts.csv -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t CreditCard -url CreditCards.csv -header true --schema.allowMissingFields true
 
 echo "Completed loading vertices into the graph $DEST_KS."
 
@@ -45,14 +50,14 @@ echo "Completed loading vertices into the graph $DEST_KS."
 ############################################
 echo "Loading edges into the graph $DEST_KS"
 
-$DSBULK load -k $DEST_KS -t Customer__owes__Loan -url "$DATADIR/owes.csv" -header true --schema.allowMissingFields true
-$DSBULK load -k $DEST_KS -t Customer__owns__Account -url "$DATADIR/owns.csv" -header true --schema.allowMissingFields true
-$DSBULK load -k $DEST_KS -t Customer__uses__CreditCard -url "$DATADIR/uses.csv" -header true --schema.allowMissingFields true
-$DSBULK load -k $DEST_KS -t Transaction__charge__CreditCard -url "$DATADIR/charge.csv" -header true --schema.allowMissingFields true
-$DSBULK load -k $DEST_KS -t Transaction__deposit_to__Account -url "$DATADIR/deposit_to.csv" -header true --schema.allowMissingFields true
-$DSBULK load -k $DEST_KS -t Transaction__withdraw_from__Account -url "$DATADIR/withdraw_from.csv" -header true --schema.allowMissingFields true
-$DSBULK load -k $DEST_KS -t Transaction__pay__Loan -url "$DATADIR/pay_loan.csv" -header true --schema.allowMissingFields true
-$DSBULK load -k $DEST_KS -t Transaction__pay__Vendor -url "$DATADIR/pay_vendor.csv" -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Customer__owes__Loan -url owes.csv -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Customer__owns__Account -url owns.csv -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Customer__uses__CreditCard -url uses.csv -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Transaction__charge__CreditCard -url charge.csv -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Transaction__deposit_to__Account -url deposit_to.csv -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Transaction__withdraw_from__Account -url withdraw_from.csv -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Transaction__pay__Loan -url pay_loan.csv -header true --schema.allowMissingFields true
+$DSBULK load -k $DEST_KS -t Transaction__pay__Vendor -url pay_vendor.csv -header true --schema.allowMissingFields true
 
 echo "Completed loading edges into the graph $DEST_KS."
 

--- a/data/ch6/ch6_load.sh
+++ b/data/ch6/ch6_load.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-# Please set the following variables
-DSBULK_PATH=/PATH/TO/dsbulk-1.3.4
-DEST_KS=trees_dev
+# You may set the following variables inside script, or override corresponding
+# variables when running the script
+DEFAULT_DSBULK_PATH=/PATH/TO/dsbulk-1.3.4
+DEFAULT_DESK_KS=trees_dev
+
+# Allow to override these variables via environment variables set before executing script
+DSBULK_PATH=${DSBULK_PATH:-$DEFAULT_DSBULK_PATH}
+DEST_KS=${DEST_KS:-$DEFAULT_DESK_KS}
 
 ############################################
 # Automated data loading 
@@ -13,26 +18,26 @@ DEST_KS=trees_dev
 OLDWD="`pwd`"
 SCRIPTIR="`dirname $0`"
 cd "$SCRIPTDIR"
-DATADIR="`pwd`"
 
 # determine which dsbulk to use, in the case you already have it installed
-DSBULK="`which dsbulk`"
-if [ -z "$DSBULK" ]; then
-    if [ ! -f "$DSBULK_PATH/bin/dsbulk" ]; then
+# the path that is set in the script, takes over the value from PATH
+DSBULK=$DSBULK_PATH/bin/dsbulk
+if [ ! -f "$DSBULK" ]; then
+    DSBULK="`which dsbulk`"
+    if [ -z "$DSBULK" ]; then
         echo "Please set DSBULK_PATH variable to top-level path of DSBulk distribution"
         echo "  or add directory with dsbulk to PATH, like, 'PATH=...dsbulk-1.3.4/bin:\$PATH'"
         exit 1
     fi
 fi
-DSBULK=$DSBULK_PATH/bin/dsbulk
 
 ############################################
 # load the vertices
 ############################################
 echo "Loading vertices into the graph $DEST_KS"
 
-$DSBULK load -k $DEST_KS -t Sensor -url "$DATADIR/Sensor.csv" -header true
-$DSBULK load -k $DEST_KS -t Tower -url "$DATADIR/Tower.csv" -header true
+$DSBULK load -k $DEST_KS -t Sensor -url Sensor.csv -header true
+$DSBULK load -k $DEST_KS -t Tower -url Tower.csv -header true
 
 
 echo "Completed loading vertices into the graph $DEST_KS."
@@ -42,8 +47,8 @@ echo "Completed loading vertices into the graph $DEST_KS."
 ############################################
 echo "Loading edges into the graph $DEST_KS"
 
-$DSBULK load -k $DEST_KS -t Sensor__send__Sensor -url "$DATADIR/Sensor__send__Sensor.csv" -header true
-$DSBULK load -k $DEST_KS -t Sensor__send__Tower -url "$DATADIR/Sensor__send__Tower.csv" -header true
+$DSBULK load -k $DEST_KS -t Sensor__send__Sensor -url Sensor__send__Sensor.csv -header true
+$DSBULK load -k $DEST_KS -t Sensor__send__Tower -url Sensor__send__Tower.csv -header true
 
 echo "Completed loading edges into the graph $DEST_KS."
 

--- a/data/ch7/ch7_load.sh
+++ b/data/ch7/ch7_load.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-# Please set the following variables
-DSBULK_PATH=/PATH/TO/dsbulk-1.3.4
-DEST_KS=trees_prod
+# You may set the following variables inside script, or override corresponding
+# variables when running the script
+DEFAULT_DSBULK_PATH=/PATH/TO/dsbulk-1.3.4
+DEFAULT_DESK_KS=trees_prod
+
+# Allow to override these variables via environment variables set before executing script
+DSBULK_PATH=${DSBULK_PATH:-$DEFAULT_DSBULK_PATH}
+DEST_KS=${DEST_KS:-$DEFAULT_DESK_KS}
 
 ############################################
 # Automated data loading 
@@ -13,26 +18,26 @@ DEST_KS=trees_prod
 OLDWD="`pwd`"
 SCRIPTIR="`dirname $0`"
 cd "$SCRIPTDIR"
-DATADIR="`pwd`"
 
 # determine which dsbulk to use, in the case you already have it installed
-DSBULK="`which dsbulk`"
-if [ -z "$DSBULK" ]; then
-    if [ ! -f "$DSBULK_PATH/bin/dsbulk" ]; then
+# the path that is set in the script, takes over the value from PATH
+DSBULK=$DSBULK_PATH/bin/dsbulk
+if [ ! -f "$DSBULK" ]; then
+    DSBULK="`which dsbulk`"
+    if [ -z "$DSBULK" ]; then
         echo "Please set DSBULK_PATH variable to top-level path of DSBulk distribution"
         echo "  or add directory with dsbulk to PATH, like, 'PATH=...dsbulk-1.3.4/bin:\$PATH'"
         exit 1
     fi
 fi
-DSBULK=$DSBULK_PATH/bin/dsbulk
 
 ############################################
 # load the vertices
 ############################################
 echo "Loading vertices into the graph $DEST_KS"
 
-$DSBULK load -k $DEST_KS -t Sensor -url "$DATADIR/Sensor.csv" -header true
-$DSBULK load -k $DEST_KS -t Tower -url "$DATADIR/Tower.csv" -header true
+$DSBULK load -k $DEST_KS -t Sensor -url Sensor.csv -header true
+$DSBULK load -k $DEST_KS -t Tower -url Tower.csv -header true
 
 echo "Completed loading vertices into the graph $DEST_KS."
 
@@ -41,8 +46,8 @@ echo "Completed loading vertices into the graph $DEST_KS."
 ############################################
 echo "Loading edges into the graph $DEST_KS"
 
-$DSBULK load -k $DEST_KS -t Sensor__send__Sensor -url "$DATADIR/Sensor__send__Sensor.csv" -header true
-$DSBULK load -k $DEST_KS -t Sensor__send__Tower -url "$DATADIR/Sensor__send__Tower.csv" -header true
+$DSBULK load -k $DEST_KS -t Sensor__send__Sensor -url Sensor__send__Sensor.csv -header true
+$DSBULK load -k $DEST_KS -t Sensor__send__Tower -url Sensor__send__Tower.csv -header true
 
 echo "Completed loading edges into the graph $DEST_KS."
 

--- a/data/ch8/ch8_load.sh
+++ b/data/ch8/ch8_load.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-# Please set the following variables
-DSBULK_PATH=/PATH/TO/dsbulk-1.3.4
-DEST_KS=paths_dev
+# You may set the following variables inside script, or override corresponding
+# variables when running the script
+DEFAULT_DSBULK_PATH=/PATH/TO/dsbulk-1.3.4
+DEFAULT_DESK_KS=paths_dev
+
+# Allow to override these variables via environment variables set before executing script
+DSBULK_PATH=${DSBULK_PATH:-$DEFAULT_DSBULK_PATH}
+DEST_KS=${DEST_KS:-$DEFAULT_DESK_KS}
 
 ############################################
 # Automated data loading 
@@ -16,15 +21,16 @@ cd "$SCRIPTDIR"
 DATADIR="`pwd`"
 
 # determine which dsbulk to use, in the case you already have it installed
-DSBULK="`which dsbulk`"
-if [ -z "$DSBULK" ]; then
-    if [ ! -f "$DSBULK_PATH/bin/dsbulk" ]; then
+# the path that is set in the script, takes over the value from PATH
+DSBULK=$DSBULK_PATH/bin/dsbulk
+if [ ! -f "$DSBULK" ]; then
+    DSBULK="`which dsbulk`"
+    if [ -z "$DSBULK" ]; then
         echo "Please set DSBULK_PATH variable to top-level path of DSBulk distribution"
         echo "  or add directory with dsbulk to PATH, like, 'PATH=...dsbulk-1.3.4/bin:\$PATH'"
         exit 1
     fi
 fi
-DSBULK=$DSBULK_PATH/bin/dsbulk
 
 ############################################
 # load the vertices
@@ -32,7 +38,7 @@ DSBULK=$DSBULK_PATH/bin/dsbulk
 echo "Loading vertices into the graph $DEST_KS"
 
 
-$DSBULK load -k $DEST_KS -t Address -url "$DATADIR/Address.csv" -header true
+$DSBULK load -k $DEST_KS -t Address -url Address.csv -header true
 
 echo "Completed loading vertices into the graph $DEST_KS."
 
@@ -41,7 +47,7 @@ echo "Completed loading vertices into the graph $DEST_KS."
 ############################################
 echo "Loading edges into the graph $DEST_KS"
 
-$DSBULK load -k $DEST_KS -t Address__rated__Address -url "$DATADIR/rated.csv" -header true
+$DSBULK load -k $DEST_KS -t Address__rated__Address -url rated.csv -header true
 
 echo "Completed loading edges into the graph $DEST_KS."
 

--- a/data/ch9/ch9_load.sh
+++ b/data/ch9/ch9_load.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-# Please set the following variables
-DSBULK_PATH=/PATH/TO/dsbulk-1.3.4
-DEST_KS=paths_prod
+# You may set the following variables inside script, or override corresponding
+# variables when running the script
+DEFAULT_DSBULK_PATH=/PATH/TO/dsbulk-1.3.4
+DEFAULT_DESK_KS=paths_prod
+
+# Allow to override these variables via environment variables set before executing script
+DSBULK_PATH=${DSBULK_PATH:-$DEFAULT_DSBULK_PATH}
+DEST_KS=${DEST_KS:-$DEFAULT_DESK_KS}
 
 ############################################
 # Automated data loading 
@@ -13,25 +18,25 @@ DEST_KS=paths_prod
 OLDWD="`pwd`"
 SCRIPTIR="`dirname $0`"
 cd "$SCRIPTDIR"
-DATADIR="`pwd`"
 
 # determine which dsbulk to use, in the case you already have it installed
-DSBULK="`which dsbulk`"
-if [ -z "$DSBULK" ]; then
-    if [ ! -f "$DSBULK_PATH/bin/dsbulk" ]; then
+# the path that is set in the script, takes over the value from PATH
+DSBULK=$DSBULK_PATH/bin/dsbulk
+if [ ! -f "$DSBULK" ]; then
+    DSBULK="`which dsbulk`"
+    if [ -z "$DSBULK" ]; then
         echo "Please set DSBULK_PATH variable to top-level path of DSBulk distribution"
         echo "  or add directory with dsbulk to PATH, like, 'PATH=...dsbulk-1.3.4/bin:\$PATH'"
         exit 1
     fi
 fi
-DSBULK=$DSBULK_PATH/bin/dsbulk
 
 ############################################
 # load the vertices
 ############################################
 echo "Loading vertices into the graph $DEST_KS"
 
-$DSBULKload -k $DEST_KS -t Address -url "$DATADIR/Address.csv" -header true
+$DSBULKload -k $DEST_KS -t Address -url Address.csv -header true
 
 echo "Completed loading vertices into the graph $DEST_KS."
 
@@ -40,7 +45,7 @@ echo "Completed loading vertices into the graph $DEST_KS."
 ############################################
 echo "Loading edges into the graph $DEST_KS"
 
-$DSBULKload -k $DEST_KS -t Address__rated__Address -url "$DATADIR/rated.csv" -header true
+$DSBULKload -k $DEST_KS -t Address__rated__Address -url rated.csv -header true
 
 echo "Completed loading edges into the graph $DEST_KS."
 


### PR DESCRIPTION
* DSBulk from the `DSBULK_PATH` takes over the DSBulk from `PATH`
* Allow to override variables for destination keyspace and DSBulk path via environment,
  without modification of the script itself, like this:

```
DSBULK_PATH=/path/to/dsbulk data/ch5/ch5_load.sh
```
